### PR TITLE
Fixing immuno builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,31 @@ immuno_analysis: data_processed
 	$(MAKE) -k -C immuno_graphical all
 
 ## immuno_report          : builds the CoVPN immunogenicity report
-immuno_report: 
+immuno_report: immuno_analysis
 	bash ./_build.sh immuno
 
 ## cor_analysis           : builds Correlates of Risk analyses
 cor_analysis: data_processed
 	$(MAKE) -k -C cor_graphical all
 	$(MAKE) -k -C cor_coxph all
+	$(MAKE) -k -C cor_threshold all
 # these will be added to cor report eventually
-#	$(MAKE) -k -C cor_threshold all
 #	$(MAKE) -k -C cor_surrogates all
 #	$(MAKE) -k -C cor_nonpar all
 
 ## cor_report             : builds the CoVPN correlates of risk report
-cor_report: 
+cor_report: cor_analysis
 	bash ./_build.sh cor
 
 ## cop_analysis           : builds Correlates of Protection analyses
-cop_analysis:
+cop_analysis: data_processed
 	$(MAKE) -k -C cop_prinstrat all
 	$(MAKE) -k -C cop_controlled all
 	$(MAKE) -k -C cop_stochastic all
 	$(MAKE) -k -C cop_mediation all
 
 ## cop_report             : builds the CoVPN correlates of protection report
-cop_report:
+cop_report: cop_analysis
 	bash ./_build.sh cop
 
 ## data_processed         : create processed data from raw data

--- a/data_clean/make_dat_proc.R
+++ b/data_clean/make_dat_proc.R
@@ -1,14 +1,20 @@
 #-----------------------------------------------
-# obligatory to append to the top of each script
-# There is a bug on Windows that prevents renv from working properly. saved.system.libPaths provides a workaround:
-if (.Platform$OS.type == "windows") saved.system.libPaths=.libPaths()
-renv::activate(project = here::here(".."))
+# NOTE: There is a bug on Windows that prevents renv from working properly.
+# saved.system.libPaths provides a workaround:
 if (.Platform$OS.type == "windows") {
-    options(renv.config.install.transactional = FALSE)
-    renv::restore(library=saved.system.libPaths, prompt=FALSE) # for a quick test, add: packages="backports"
-    .libPaths(c(saved.system.libPaths, .libPaths()))
-} else renv::restore(prompt=FALSE)
-
+  saved.system.libPaths <- .libPaths()
+}
+renv::activate(project = here::here())
+# NOTE: I don't think we want to renv::restore() everytime, this is better
+#       done manually while developing analysis code -Nima
+# if (.Platform$OS.type == "windows") {
+#   options(renv.config.install.transactional = FALSE)
+#   # for a quick test, add: packages="backports"
+#   renv::restore(library = saved.system.libPaths, prompt = FALSE)
+#   .libPaths(c(saved.system.libPaths, .libPaths()))
+# } else {
+#   renv::restore(prompt = FALSE)
+# }
 source(here::here("_common.R"))
 #-----------------------------------------------
 

--- a/immuno_graphical/Makefile
+++ b/immuno_graphical/Makefile
@@ -1,5 +1,5 @@
 ## all              : twophase_plots + demog_plots
-all: twophase_plots demog_plots
+all: clean twophase_plots demog_plots
 
 ## twophase_plots   : rcdfs, boxplots, scatter plots of assays saved in figs/
 twophase_plots: code/descriptive_graphics_two_phase_plots.R \

--- a/immuno_graphical/report.Rmd
+++ b/immuno_graphical/report.Rmd
@@ -3,6 +3,7 @@
 ## Pairs plots of antibody markers for overall per-protocal cohort
 
 ### Baseline SARS-CoV-2 Negative
+
 ```{r immuno-graphical-setup, echo = FALSE, message = FALSE}
 library(here)
 library(latex2exp)
@@ -33,7 +34,6 @@ include_graphics(here(
 ))
 ```
 
-
 ```{r, fig.cap = "(Mock data) Pair plots of D57 Ab markers: baseline negative vaccine arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -44,7 +44,6 @@ include_graphics(here(
 ))
 ```
 
-
 ```{r, fig.cap = "(Mock data) Pair plots of D29 fold-rise over D1 Ab markers: baseline negative vaccine arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -54,7 +53,6 @@ include_graphics(here(
   )
 ))
 ```
-
 
 ```{r, fig.cap = "(Mock data) Pair plots of D57 fold-rise over D1 Ab markers: baseline negative vaccine arm"}
 include_graphics(here(
@@ -96,7 +94,6 @@ include_graphics(here(
 ))
 ```
 
-
 ```{r, fig.cap = "(Mock data) Pair plots of D1, D29 and D57 PsV Neutralization 80% Titer: Baseline negative vaccine + placebo arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -106,8 +103,6 @@ include_graphics(here(
   )
 ))
 ```
-
-
 
 ### Baseline SARS-CoV-2 Positive
 
@@ -121,8 +116,6 @@ include_graphics(here(
 ))
 ```
 
-
-
 ```{r, fig.cap = "(Mock data) Pair plots of D29 Ab markers: baseline positive vaccine arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -132,7 +125,6 @@ include_graphics(here(
   )
 ))
 ```
-
 
 ```{r, fig.cap = "(Mock data) Pair plots of D57 Ab markers: baseline positive vaccine arm"}
 include_graphics(here(
@@ -144,7 +136,6 @@ include_graphics(here(
 ))
 ```
 
-
 ```{r, fig.cap = "(Mock data) Pair plots of D29 fold-rise over D1 Ab markers: baseline positive vaccine arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -154,7 +145,6 @@ include_graphics(here(
   )
 ))
 ```
-
 
 ```{r, fig.cap = "(Mock data) Pair plots of D57 fold-rise over D1 Ab markers: baseline positive vaccine arm"}
 include_graphics(here(
@@ -196,7 +186,6 @@ include_graphics(here(
 ))
 ```
 
-
 ```{r, fig.cap = "(Mock data) Pair plots of D1, D29 and D57 PsV Neutralization 80% Titer: baseline positive vaccine + placebo arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -206,7 +195,6 @@ include_graphics(here(
   )
 ))
 ```
-
 
 ## RCDF plots of antibody markers for overall per-protocol cohort
 
@@ -330,7 +318,6 @@ include_graphics(here(
 ))
 ```
 
-
 ## Box plots of antibody markers for overall per-protocol cohort
 
 ### Baseline SARS-CoV-2 negative
@@ -365,7 +352,6 @@ include_graphics(here(
 
 ### Baseline SARS-CoV-2 positive
 
-
 ```{r, fig.cap = "(Mock data) Boxplots of D29 Ab markers: baseline positive vaccine + placebo arms"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -394,9 +380,7 @@ include_graphics(here(
 ))
 ```
 
-
 ### Baseline negative vs. positive vaccine recipients
-
 
 ```{r, fig.cap = "(Mock data) Boxplots of D29 Ab markers: baseline positive + negative vaccine arm"}
 include_graphics(here(
@@ -426,10 +410,7 @@ include_graphics(here(
 ))
 ```
 
-
 ### Baseline negative vs. positive placebo recipients
-
-
 
 ```{r, fig.cap = "(Mock data) Boxplots of D29 Ab markers: baseline positive + negative placebo arm"}
 include_graphics(here(
@@ -462,6 +443,7 @@ include_graphics(here(
 ## Spaghetti plots of antibody markers over time for the overall per-protocol cohort
 
 ### Baseline SARS-CoV-2 negative
+
 ```{r, fig.cap = "(Mock data) Spaghetti plots of Ab markers over time: baseline negative vaccine + placebo arm"}
 include_graphics(here(
   "immuno_graphical", "figs",
@@ -476,7 +458,6 @@ include_graphics(here(
   paste0("spaghetti_plot_BaselinePos_", study_name, ".png")
 ))
 ```
-
 
 ## RCDF plots of antibody markers by demographics for per-protocol cohort
 
@@ -852,10 +833,7 @@ include_graphics(here(
 ))
 ```
 
-
 ### Baseline SARS-CoV-2 positive
-
-
 
 ```{r, fig.cap = "(Mock data) RCDF plots for D29 Ab markers: baseline positive vaccine arm by age groups."}
 include_graphics(here(
@@ -1216,7 +1194,6 @@ include_graphics(here(
   )
 ))
 ```
-
 
 ## Boxplots of antibody markers by demographics for per-protocol cohort
 

--- a/immuno_tabular/code/make_clean_data.R
+++ b/immuno_tabular/code/make_clean_data.R
@@ -10,6 +10,8 @@ load(here("data_clean", "params.Rdata"))
 
 # Read in original data
 dat.mock <- read.csv(here("..", "data_clean", data_name))
+dat.mock$wt[is.na(dat.mock$wt)] <- 0
+dat.mock$wt.2[is.na(dat.mock$wt.2)] <- 0
 
 ds_o <- dat.mock
 # The stratified random cohort for immunogenicity


### PR DESCRIPTION
This PR attempts to tighten the `make` recipes for the immunogenicity reporting workflow, including making sure that all intermediary data and figures are cleared prior to running of `make immuno_report`. It also tries to address #78, which appears difficult to replicate. What's more, the immunogenicity tables reporting is currently broken by the introduction of weights that contain missing values, which were added to `_common.R`.