### PR TITLE
purge `magick` dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ apt_packages:
   - libcurl4-openssl-dev
 
 before_install:
-  - sudo add-apt-repository -y ppa:cran/imagemagick
-  - sudo apt-get update
-  - sudo apt-get install -y libmagick++-dev
   - sudo apt-get install -y texlive-extra-utils ghostscript
 
 # R packages cannot be installed in TRAVIS_BUILD_DIR; they need to be installed

--- a/renv.lock
+++ b/renv.lock
@@ -1031,13 +1031,6 @@
       "Repository": "CRAN",
       "Hash": "1ebfdc8a3cfe8fe19184f5481972b092"
     },
-    "magick": {
-      "Package": "magick",
-      "Version": "2.6.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ffc87958461a1d2a5ec4b36035b87b94"
-    },
     "magrittr": {
       "Package": "magrittr",
       "Version": "2.0.1",


### PR DESCRIPTION
Remove remaining traces of `magick` in the `.travis.yml` and `renv.lock` files to address #123.