### PR TITLE
add watermark to reports

### DIFF
--- a/index_cop.Rmd
+++ b/index_cop.Rmd
@@ -14,6 +14,8 @@ graphics: yes
 lot: yes
 lof: yes
 always_allow_html: yes
+header-includes:
+   - \usepackage{eso-pic,graphicx,transparent}
 ---
 
 ```{r, include = knitr::is_latex_output() & study_name == "mock"}

--- a/index_cop.Rmd
+++ b/index_cop.Rmd
@@ -16,6 +16,17 @@ lof: yes
 always_allow_html: yes
 ---
 
+```{r, source-common, include = FALSE}
+here::here("_common.R")
+```
+
+```{r, include = knitr::is_latex_output() & study_name == "mock"}
+knitr::asis_output("\\AddToShipoutPictureFG{
+  \\AtPageCenter{
+    \\makebox[0pt]{\\rotatebox[origin=c]{45}{
+      \\scalebox{10}{\\texttransparent{0.3}{MOCK}}}}}}")
+```
+
 `r if (knitr::is_latex_output()) '<!--'`
 
 # CoVPN Correlates Analysis Report {-}

--- a/index_cop.Rmd
+++ b/index_cop.Rmd
@@ -16,10 +16,6 @@ lof: yes
 always_allow_html: yes
 ---
 
-```{r, source-common, include = FALSE}
-here::here("_common.R")
-```
-
 ```{r, include = knitr::is_latex_output() & study_name == "mock"}
 knitr::asis_output("\\AddToShipoutPictureFG{
   \\AtPageCenter{

--- a/index_cor.Rmd
+++ b/index_cor.Rmd
@@ -18,10 +18,6 @@ header-includes:
    - \usepackage{eso-pic,graphicx,transparent}
 ---
 
-```{r, source-common, include = FALSE}
-here::here("_common.R")
-```
-
 ```{r, include = knitr::is_latex_output() & study_name == "mock"}
 knitr::asis_output("\\AddToShipoutPictureFG{
   \\AtPageCenter{

--- a/index_cor.Rmd
+++ b/index_cor.Rmd
@@ -14,7 +14,20 @@ graphics: yes
 lot: yes
 lof: yes
 always_allow_html: yes
+header-includes:
+   - \usepackage{eso-pic,graphicx,transparent}
 ---
+
+```{r, source-common, include = FALSE}
+here::here("_common.R")
+```
+
+```{r, include = knitr::is_latex_output() & study_name == "mock"}
+knitr::asis_output("\\AddToShipoutPictureFG{
+  \\AtPageCenter{
+    \\makebox[0pt]{\\rotatebox[origin=c]{45}{
+      \\scalebox{10}{\\texttransparent{0.3}{MOCK}}}}}}")
+```
 
 `r if (knitr::is_latex_output()) '<!--'`
 

--- a/index_immuno.Rmd
+++ b/index_immuno.Rmd
@@ -2,7 +2,8 @@
 knit: "bookdown::render_book"
 title: "COVID-19 Immunogenicity Analysis Report"
 author: "USG COVID-19 Response Biostatistics Team"
-date: "`r format(Sys.time(), '%B %d, %Y')`"
+date: "`r format(Sys.tim
+	e(), '%B %d, %Y')`"
 documentclass: book
 site: bookdown::bookdown_site
 bibliography: [book.bib, packages.bib]
@@ -14,6 +15,8 @@ graphics: yes
 lot: yes
 lof: yes
 always_allow_html: yes
+header-includes:
+   - \usepackage{eso-pic,graphicx,transparent}
 ---
 
 

--- a/index_immuno.Rmd
+++ b/index_immuno.Rmd
@@ -16,6 +16,17 @@ lof: yes
 always_allow_html: yes
 ---
 
+```{r, source-common, include = FALSE}
+here::here("_common.R")
+```
+
+```{r, include = knitr::is_latex_output() & study_name == "mock"}
+knitr::asis_output("\\AddToShipoutPictureFG{
+  \\AtPageCenter{
+    \\makebox[0pt]{\\rotatebox[origin=c]{45}{
+      \\scalebox{10}{\\texttransparent{0.3}{MOCK}}}}}}")
+```
+
 `r if (knitr::is_latex_output()) '<!--'`
 
 # CoVPN Correlates Analysis Report {-}

--- a/index_immuno.Rmd
+++ b/index_immuno.Rmd
@@ -16,9 +16,6 @@ lof: yes
 always_allow_html: yes
 ---
 
-```{r, source-common, include = FALSE}
-here::here("_common.R")
-```
 
 ```{r, include = knitr::is_latex_output() & study_name == "mock"}
 knitr::asis_output("\\AddToShipoutPictureFG{

--- a/index_immuno.Rmd
+++ b/index_immuno.Rmd
@@ -2,8 +2,7 @@
 knit: "bookdown::render_book"
 title: "COVID-19 Immunogenicity Analysis Report"
 author: "USG COVID-19 Response Biostatistics Team"
-date: "`r format(Sys.tim
-	e(), '%B %d, %Y')`"
+date: "`r format(Sys.time(), '%B %d, %Y')`"
 documentclass: book
 site: bookdown::bookdown_site
 bibliography: [book.bib, packages.bib]


### PR DESCRIPTION
This addresses #179 by adding a transparent gray watermark to reports if `study_name == "mock"` (and the output is `latex`, which is always is for now).

The watermark doesn't render on the title page and some pages of the TOC (no idea why), but this seems OK, as the most important thing is making sure results pages have the MOCK watermark applied.