### PR TITLE
add subtitle with study name to each report

### DIFF
--- a/index_cop.Rmd
+++ b/index_cop.Rmd
@@ -1,6 +1,7 @@
 ---
 knit: "bookdown::render_book"
 title: "COVID-19 Correlates of Protection Analysis Report"
+subtitle: '`r source(here::here("_common.R")); paste(study_name, "Study")`'
 author: "USG COVID-19 Response Biostatistics Team"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 documentclass: book

--- a/index_cor.Rmd
+++ b/index_cor.Rmd
@@ -1,6 +1,7 @@
 ---
 knit: "bookdown::render_book"
 title: "COVID-19 Correlates of Risk Analysis Report"
+subtitle: '`r source(here::here("_common.R")); paste(study_name, "Study")`'
 author: "USG COVID-19 Response Biostatistics Team"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 documentclass: book

--- a/index_immuno.Rmd
+++ b/index_immuno.Rmd
@@ -1,6 +1,7 @@
 ---
 knit: "bookdown::render_book"
 title: "COVID-19 Immunogenicity Analysis Report"
+subtitle: '`r source(here::here("_common.R")); paste(study_name, "Study")`'
 author: "USG COVID-19 Response Biostatistics Team"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 documentclass: book


### PR DESCRIPTION
This, rather inelegantly, adds `study_name` as a subtitle to the report in response to issue #178 