### PR TITLE
solving problem with tex live updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
   directories:
   - "$HOME/.local/share/renv"
   - "$TRAVIS_BUILD_DIR/renv/library"
-  - "$HOME/.TinyTeX/"
 
 # which versions of R should we build on
 r:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
   directories:
   - "$HOME/.local/share/renv"
   - "$TRAVIS_BUILD_DIR/renv/library"
+  - "$HOME/.TinyTeX/"
 
 # which versions of R should we build on
 r:
@@ -36,7 +37,7 @@ before_install:
 # tinytex installs tlmgr to a directory that is symlinked to $HOME/bin
 install:
   - cd .. && Rscript -e "install.packages(c('here', 'renv', 'tinytex'))"
-  - Rscript -e "tinytex::install_tinytex()"
+  - Rscript -e "tinytex::reinstall_tinytex()"
   - export PATH=$HOME/bin:${PATH}
   - tlmgr install threeparttablex
   - cd $TRAVIS_BUILD_DIR && Rscript -e "renv::restore()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ before_install:
 # tinytex installs tlmgr to a directory that is symlinked to $HOME/bin
 install:
   - cd .. && Rscript -e "install.packages(c('here', 'renv', 'tinytex'))"
-  - Rscript -e "tinytex::install_tinytex(TRUE, repository = 'https://ctan.math.illinois.edu/systems/texlive/tlnet/')"
+  - Rscript -e "tinytex::install_tinytex(TRUE, repository = 'http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet')"
+  - tmlgr install threeparttablex
   - export PATH=$HOME/bin:${PATH}
   - cd $TRAVIS_BUILD_DIR && Rscript -e "renv::restore()"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 # tinytex installs tlmgr to a directory that is symlinked to $HOME/bin
 install:
   - cd .. && Rscript -e "install.packages(c('here', 'renv', 'tinytex'))"
-  - Rscript -e "tinytex::install_tinytex(repository = 'https://ctan.math.illinois.edu/systems/texlive/tlnet/')"
+  - Rscript -e "tinytex::install_tinytex(TRUE, repository = 'https://ctan.math.illinois.edu/systems/texlive/tlnet/')"
   - export PATH=$HOME/bin:${PATH}
   - tlmgr install threeparttablex
   - cd $TRAVIS_BUILD_DIR && Rscript -e "renv::restore()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - cd .. && Rscript -e "install.packages(c('here', 'renv', 'tinytex'))"
   - Rscript -e "tinytex::install_tinytex(TRUE, repository = 'https://ctan.math.illinois.edu/systems/texlive/tlnet/')"
   - export PATH=$HOME/bin:${PATH}
-  - tlmgr install threeparttablex
   - cd $TRAVIS_BUILD_DIR && Rscript -e "renv::restore()"
 
 # turn down number of bootstraps and permutations in CoR for faster builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ apt_packages:
   - libcurl4-openssl-dev
 
 before_install:
-  - sudo apt-get install -y texlive-extra-utils ghostscript
+  - sudo apt-get install -y texlive-extra-utils ghostscript # do we need these anymore?
 
 # R packages cannot be installed in TRAVIS_BUILD_DIR; they need to be installed
 # separately from the lockfile
 # tinytex installs tlmgr to a directory that is symlinked to $HOME/bin
 install:
   - cd .. && Rscript -e "install.packages(c('here', 'renv', 'tinytex'))"
-  - Rscript -e "tinytex::reinstall_tinytex()"
+  - Rscript -e "tinytex::install_tinytex(repository = 'https://ctan.math.illinois.edu/systems/texlive/tlnet/')"
   - export PATH=$HOME/bin:${PATH}
   - tlmgr install threeparttablex
   - cd $TRAVIS_BUILD_DIR && Rscript -e "renv::restore()"


### PR DESCRIPTION
Current builds are erroring because `texlive` has been updated and calls to `tlmgr` are not backwards compatible (apparently). This PR is attempting to resolve this issue.