### PR TITLE
update TwophasesampInd to include pseudoneuts and be "assay aware"

### DIFF
--- a/_common.R
+++ b/_common.R
@@ -59,6 +59,11 @@ uloqs <-c(
 
 convf=c(bindSpike=0.0090, bindN=0.0024, bindRBD=0.0272)
 
+must_have_assays <- c(
+  "bindSpike", "bindRBD"
+  # NOTE: the live neutralization marker will eventually be available
+  #"liveneutmn50"
+)
 
 ###############################################################################
 # figure labels and titles for markers

--- a/data_clean/make_dat_proc.R
+++ b/data_clean/make_dat_proc.R
@@ -233,7 +233,9 @@ stopifnot(
 dat_proc[dat_proc$TwophasesampInd==1, imp.markers] <-
   dat.tmp.impute[imp.markers][match(dat_proc[dat_proc$TwophasesampInd==1, "Ptid"], dat.tmp.impute$Ptid), ]
 
-
+stopifnot(
+  all(complete.cases(dat_proc[dat_proc$TwophasesampInd == 1, imp.markers]))
+)
 
 ###############################################################################
 # impute again for TwophasesampInd.2

--- a/data_clean/make_dat_proc.R
+++ b/data_clean/make_dat_proc.R
@@ -34,18 +34,18 @@ dat_proc <- dat_proc %>%
     TwophasesampInd = Perprotocol == 1 &
       (SubcohortInd | EventIndPrimaryD29 == 1) &
       complete.cases(cbind(
-        if("bindSpike" %in% assays) BbindSpike, 
-        if("bindSpike" %in% assays & has29) Day29bindSpike, 
-        if("bindSpike" %in% assays) Day57bindSpike,
-        if("bindRBD" %in% assays) BbindRBD, 
-        if("bindRBD" %in% assays & has29) Day29bindRBD, 
-        if("bindRBD" %in% assays) Day57bindRBD,
-        if("pseudoneutid50" %in% assays) Bpseudoneutid50, 
-        if("pseudoneutid50" %in% assays & has29) Day29pseudoneutid50, 
-        if("pseudoneutid50" %in% assays) Day57pseudoneutid50,
-        if("pseudoneutid80" %in% assays) Bpseudoneutid80, 
-        if("pseudoneutid80" %in% assays & has29) Day29pseudoneutid80, 
-        if("pseudoneutid80" %in% assays) Day57pseudoneutid80
+        if("bindSpike" %in% must_have_assays) BbindSpike, 
+        if("bindSpike" %in% must_have_assays & has29) Day29bindSpike, 
+        if("bindSpike" %in% must_have_assays) Day57bindSpike,
+        if("bindRBD" %in% must_have_assays) BbindRBD, 
+        if("bindRBD" %in% must_have_assays & has29) Day29bindRBD, 
+        if("bindRBD" %in% must_have_assays) Day57bindRBD,
+        if("pseudoneutid50" %in% must_have_assays) Bpseudoneutid50, 
+        if("pseudoneutid50" %in% must_have_assays & has29) Day29pseudoneutid50, 
+        if("pseudoneutid50" %in% must_have_assays) Day57pseudoneutid50,
+        if("pseudoneutid80" %in% must_have_assays) Bpseudoneutid80, 
+        if("pseudoneutid80" %in% must_have_assays & has29) Day29pseudoneutid80, 
+        if("pseudoneutid80" %in% must_have_assays) Day57pseudoneutid80
       ))
   )
 
@@ -56,14 +56,14 @@ if(has29) dat_proc <- dat_proc %>%
     TwophasesampInd.2 = Perprotocol == 1 &
       (SubcohortInd | EventIndPrimaryD29 == 1) &
       complete.cases(cbind(
-        if("bindSpike" %in% assays) BbindSpike, 
-        if("bindSpike" %in% assays) Day29bindSpike,
-        if("bindRBD" %in% assays) BbindRBD, 
-        if("bindRBD" %in% assays) Day29bindRBD,
-        if("pseudoneutid50" %in% assays) Bpseudoneutid50, 
-        if("pseudoneutid50" %in% assays) Day29pseudoneutid50, 
-        if("pseudoneutid80" %in% assays) Bpseudoneutid80, 
-        if("pseudoneutid80" %in% assays) Day29pseudoneutid80
+        if("bindSpike" %in% must_have_assays) BbindSpike, 
+        if("bindSpike" %in% must_have_assays) Day29bindSpike,
+        if("bindRBD" %in% must_have_assays) BbindRBD, 
+        if("bindRBD" %in% must_have_assays) Day29bindRBD,
+        if("pseudoneutid50" %in% must_have_assays) Bpseudoneutid50, 
+        if("pseudoneutid50" %in% must_have_assays) Day29pseudoneutid50, 
+        if("pseudoneutid80" %in% must_have_assays) Bpseudoneutid80, 
+        if("pseudoneutid80" %in% must_have_assays) Day29pseudoneutid80
       ))
   )
   

--- a/data_clean/make_dat_proc.R
+++ b/data_clean/make_dat_proc.R
@@ -34,8 +34,18 @@ dat_proc <- dat_proc %>%
     TwophasesampInd = Perprotocol == 1 &
       (SubcohortInd | EventIndPrimaryD29 == 1) &
       complete.cases(cbind(
-        BbindSpike, if(has29) Day29bindSpike, Day57bindSpike,
-        BbindRBD,   if(has29) Day29bindRBD,   Day57bindRBD
+        if("bindSpike" %in% assays) BbindSpike, 
+        if("bindSpike" %in% assays & has29) Day29bindSpike, 
+        if("bindSpike" %in% assays) Day57bindSpike,
+        if("bindRBD" %in% assays) BbindRBD, 
+        if("bindRBD" %in% assays & has29) Day29bindRBD, 
+        if("bindRBD" %in% assays) Day57bindRBD,
+        if("pseudoneutid50" %in% assays) Bpseudoneutid50, 
+        if("pseudoneutid50" %in% assays & has29) Day29pseudoneutid50, 
+        if("pseudoneutid50" %in% assays) Day57pseudoneutid50,
+        if("pseudoneutid80" %in% assays) Bpseudoneutid80, 
+        if("pseudoneutid80" %in% assays & has29) Day29pseudoneutid80, 
+        if("pseudoneutid80" %in% assays) Day57pseudoneutid80
       ))
   )
 
@@ -46,8 +56,14 @@ if(has29) dat_proc <- dat_proc %>%
     TwophasesampInd.2 = Perprotocol == 1 &
       (SubcohortInd | EventIndPrimaryD29 == 1) &
       complete.cases(cbind(
-        BbindSpike, Day29bindSpike,
-        BbindRBD, Day29bindRBD
+        if("bindSpike" %in% assays) BbindSpike, 
+        if("bindSpike" %in% assays) Day29bindSpike,
+        if("bindRBD" %in% assays) BbindRBD, 
+        if("bindRBD" %in% assays) Day29bindRBD,
+        if("pseudoneutid50" %in% assays) Bpseudoneutid50, 
+        if("pseudoneutid50" %in% assays) Day29pseudoneutid50, 
+        if("pseudoneutid80" %in% assays) Bpseudoneutid80, 
+        if("pseudoneutid80" %in% assays) Day29pseudoneutid80
       ))
   )
   


### PR DESCRIPTION
We ran into a bug in the MRNA analysis where baseline pseudoneut was missing but those observations were not being filtered out based on `TwophasesampInd`. We traced back to data processing script, which previously only looked at `bindRBD` and `bindSpike` to define `TwophasesampInd`.

The PR checks for complete cases of the user-specified (via `_common.R` script) `assays` and includes new lines checking for `complete.cases` of the pseudo neuts.