### PR TITLE
update wrcdf plot to handle 0-width CIs

### DIFF
--- a/cor_graphical/code/cor_wrcdf_plot_function.R
+++ b/cor_graphical/code/cor_wrcdf_plot_function.R
@@ -70,8 +70,6 @@ covid_corr_rcdf_ve_lines <- function(
     geom_rect(data = data.frame(x = min(xgrid), rcdf = 1), 
               aes(xmin = min(xgrid),xmax = line_top, ymin = VE_lb, ymax = VE_ub), 
               fill = "grey", alpha = 0.3) +
-    geom_ribbon(data = dat_areaV, aes(ymin = 0, ymax = rcdf), 
-                alpha = 0.3, fill = "grey") +
     geom_segment(data = dat_seg,
                  aes(x = x, y = y, xend = xend, yend = yend, linetype = type),
                  color = "red",
@@ -96,6 +94,15 @@ covid_corr_rcdf_ve_lines <- function(
           axis.title = element_text(size = axis_title_size),
           axis.text = element_text(size = axis_size))
   
+  # if entire VE CI falls in a flat region of the RCDF curve, there 
+  # will be no points between line_low and line_top (thus, nrow(dat_areaV) == 0), 
+  # in which case we will not draw the ribbon
+  if(nrow(dat_areaV) > 0){
+    output_plot <- output_plot +
+      geom_ribbon(data = dat_areaV, aes(ymin = 0, ymax = rcdf), 
+                  alpha = 0.3, fill = "grey")
+  }
+
   ggsave(
     filename = filename, plot = output_plot, width = width,
     height = height, units = units


### PR DESCRIPTION
@KenLi93, see if you agree with this change. 

Here, we still draw the red lines if CI is width 0, but we do not attempt to add the gray ribbon.