### PR TITLE
fix error with cor_threshold tables

### DIFF
--- a/cor_threshold/code/plotting_helpers.R
+++ b/cor_threshold/code/plotting_helpers.R
@@ -137,7 +137,7 @@ generate_tables <- function(marker, num_show = 10, monotone = F) {
   esttmle_table[, 6] <- round(esttmle_table[, 6], 5)
   esttmle_table[, 7] <- round(esttmle_table[, 7], 5)
   esttmle_table <- esttmle_table[,c(1:7)]
-  esttmle_table <- data.frame(esttmle_table, paste0(gsub("e\\+0|e\\-0", " * 10$^", format(10^esttmle_table[, 1], scientific = T, digits = 3)), "$"))
+  esttmle_table <- data.frame(esttmle_table, paste0(gsub("e\\+0|e\\-0", " * 10$^{", format(10^esttmle_table[, 1], scientific = T, digits = 3)), "}$"))
   esttmle_table <- esttmle_table[, c(1, 8, 2, 4, 5, 6, 7)]
   esttmle_table[esttmle_table[, 3] < 0, 3] <- 0
   colnames(esttmle_table) <- c("log$_{10}$-Threshold", "Threshold", "Risk estimate", "CI left", "CI right", "CI left", "CI right")

--- a/cor_threshold/code/plotting_helpers.R
+++ b/cor_threshold/code/plotting_helpers.R
@@ -137,7 +137,7 @@ generate_tables <- function(marker, num_show = 10, monotone = F) {
   esttmle_table[, 6] <- round(esttmle_table[, 6], 5)
   esttmle_table[, 7] <- round(esttmle_table[, 7], 5)
   esttmle_table <- esttmle_table[,c(1:7)]
-  esttmle_table <- data.frame(esttmle_table, paste0(gsub("e\\+0", " * 10$^", format(10^esttmle_table[, 1], scientific = T, digits = 3)), "$"))
+  esttmle_table <- data.frame(esttmle_table, paste0(gsub("e\\+0|e\\-0", " * 10$^", format(10^esttmle_table[, 1], scientific = T, digits = 3)), "$"))
   esttmle_table <- esttmle_table[, c(1, 8, 2, 4, 5, 6, 7)]
   esttmle_table[esttmle_table[, 3] < 0, 3] <- 0
   colnames(esttmle_table) <- c("log$_{10}$-Threshold", "Threshold", "Risk estimate", "CI left", "CI right", "CI left", "CI right")


### PR DESCRIPTION
if `esttmle_table[,1]` has values with `e-0x` in them the previous code would not `gsub` these expressions, which would cause an errant `$` to appear at the end of the line.

@Larsvanderlaan, will the following fix work? The `gsub` syntax is solid, but not 100% clear to me whether the `format(...)` will properly display a negative number in the exponent? It may need to be wrapped in (escaped) `{ }` to work.