### PR TITLE
Add single mediation result to CoR report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,4 @@ cor_coxph/output/D57/marginalized_risks_eq_MockCOVE.tex
 cor_graphical/.Rprofile
 cor_graphical/renv/activate.R
 .Makefile.swp
+cop_mediation/*.html

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cor_analysis: data_processed
 	$(MAKE) -k -C cor_graphical all
 	$(MAKE) -k -C cor_threshold all
 	$(MAKE) -k -C cor_nonlinear all
+	$(MAKE) -k -C cop_mediation all
 	$(MAKE) -k -C cor_surrogates all
 # will be added to the CoR report eventually
 #	$(MAKE) -k -C cor_surrogates all

--- a/_bookdown_cor.yml
+++ b/_bookdown_cor.yml
@@ -18,6 +18,7 @@ rmd_files: [
   "cor_coxph/report.Rmd",
   "cor_threshold/report.Rmd",
   "cor_nonlinear/report.Rmd",
+  "cop_mediation/report.Rmd",
   "cor_surrogates/report.Rmd",
   "references.Rmd",
   "appendix.Rmd"

--- a/cop_mediation/code/clean_data.R
+++ b/cop_mediation/code/clean_data.R
@@ -3,8 +3,11 @@
 renv::activate(project = here::here(".."))
 source(here::here("..", "_common.R"))
 #-----------------------------------------------
+# load parameters
+source(here::here("code", "params.R"))
+
 # load data
-full_data <- read.csv(here::here("..", "data_clean", data_name))
+full_data <- read.csv(here::here("..", "data_clean", data_name_updated))
 
 # define trichotomized markers
 #   adding 1e-6 to the first cut point helps avoid an error when 33% is the minimial value
@@ -13,7 +16,7 @@ full_data <- read.csv(here::here("..", "data_clean", data_name))
 marker.cutpoints <- list()    
 for (a in assays) {
     marker.cutpoints[[a]] <- list()    
-    for (ind.t in c("Day57", "Day29")) {
+    for (ind.t in times) {
         if(ind.t == "Day57"){
           dat.vacc.pop=subset(full_data, Trt==1 & Bserostatus==0 & !is.na(wt.D57))
           wt <- dat.vacc.pop$wt.D57
@@ -29,9 +32,6 @@ for (a in assays) {
     }
 }
 
-# load parameters
-source(here::here("code", "params.R"))
-
 # Generate the outcome and censoring indicator variables
 for (time in times) {
   print(time)
@@ -39,9 +39,8 @@ for (time in times) {
   outcome <-
     data[[Event_Ind_variable[[time]]]] == 1 & data[[Event_Time_variable[[time]]]] <= tf[[time]]
   outcome <- as.numeric(outcome)
-  # TO CHANGE
-  
-  if(adjust_for_censoring) {
+
+  if(FALSE) {
   Delta <-
     1 - (data[[Event_Ind_variable[[time]]]] == 0 &
       data[[Event_Time_variable[[time]]]] < tf[[time]])
@@ -60,14 +59,15 @@ for (time in times) {
   variables_to_keep <-
     c(
       covariates,
-      markers[marker_to_time[markers] == time],
+      c(outer(times, assays, FUN=paste0)),
       "TwophasesampInd",
       #"grp",
+      "Trt",
       "wt",
       "outcome",
-      "Delta",
-      "Trt"
+      "Delta"
     )
+
   keep <- data$Bserostatus == 0 & !is.na(data$wt)
   
   data_keep <- data[keep, variables_to_keep]
@@ -80,7 +80,7 @@ for (time in times) {
   variables_to_keep_cat <-
     c(
       covariates,
-      paste0(markers[marker_to_time[markers] == time], "cat"),
+      paste0(c(outer(times, assays, FUN=paste0)), "cat"),
       "TwophasesampInd",
       #"grp",
       "wt",

--- a/cop_mediation/code/format_utils.R
+++ b/cop_mediation/code/format_utils.R
@@ -20,8 +20,8 @@ format_row <- function(fit, digits = 3){
   g <- matrix(c(log(direct_eff)/(log(total_eff))^2*1/risk_est[1], log(indirect_eff)/(log(total_eff))^2*1/risk_est[2],
               -1/(risk_est[3]*log(total_eff)), 0))
   se_prop_med <- sqrt(t(g) %*% fit$cov %*% g)
-  cil <- prop_med - qnorm(0.975) * se_prop_med
-  ciu <- prop_med + qnorm(0.975) * se_prop_med
+  cil <- prop_med + qnorm(0.975) * se_prop_med
+  ciu <- prop_med - qnorm(0.975) * se_prop_med
 
   this_row <- c(
     format_ci(1 - fit$eff["Direct", 2:4], digits = digits),

--- a/cop_mediation/code/params.R
+++ b/cop_mediation/code/params.R
@@ -4,23 +4,50 @@ renv::activate(project = here::here(".."))
 source(here::here("..", "_common.R"))
 #-----------------------------------------------
 
+full_data <- read.csv(here::here("..", "data_clean", data_name))
 
-tf <- list("Day57" = 172, "Day29" = 200) # Reference time to perform analysis. Y = 1(T <= tf) where T is event time of Covid.
+if(has29){
+    tf_Day29 <- max(full_data[full_data$EventIndPrimaryD29==1 & full_data$Trt == 1 & full_data$Bserostatus == 0 & !is.na(full_data$wt.D29), "EventTimePrimaryD29" ])
+    tf_Day57 <- max(full_data[full_data$EventIndPrimaryD57==1 & full_data$Trt == 1 & full_data$Bserostatus == 0 & !is.na(full_data$wt.D57), "EventTimePrimaryD57" ])
+tf <- list("Day57" = tf_Day57, "Day29" = tf_Day29)
+} else {
+    tf_Day57 <- max(full_data[full_data$EventIndPrimaryD57==1 & full_data$Trt == 1 & full_data$Bserostatus == 0 & !is.na(full_data$wt.D57), "EventTimePrimaryD57" ])
+    tf <- list("Day57" = tf_Day57)
 
-times <- intersect(c("Day57", "Day29"), times)
+}# Reference time to perform analysis. Y = 1(T <= tf) where T is event time of Covid.
+# tf should be large enough that most events are observed but small enough so that not many people are right censored. For the practice dataset, tf = 170 works.
+# Right-censoring is taken into account for  this analysis.
+
+if(study_name_code != "COVE"){
+  times <- intersect(c("Day57", "Day29"), times)
+}else{
+  times <- "Day29"
+  assays <- "pseudoneutid80"
+}
+# Marker variables to generate results for
+# assays <- c("bindSpike", "bindRBD", "pseudoneutid80", "liveneutid80", "pseudoneutid80", "liveneutid80", "pseudoneutid50", "liveneutid50")
+# assays <- paste0("Day57", assays) # Quick way to switch between days
 markers <- unlist(sapply(times, function(v) grep(v, markers, value = T))) # Remove the baseline markers
-markers
 marker_to_time <- sapply(markers, function(v) {
   times[stringr::str_detect(v, times)]
 })
 marker_to_assay <- sapply(markers, function(v) {
-  assays[stringr::str_detect(v, assays)]
+  unname(assays[stringr::str_detect(v, assays)])
 })
 
-# analysis with more minimal super learner library
-fast_run <- TRUE
 # Covariates to adjust for. SHOULD BE AT LEAST TWO VARIABLES OR GLMNET WILL ERROR
-covariates <- c("MinorityInd", "HighRiskInd") # , "BRiskScore") # Add "age"?
+data_name_updated <- sub(".csv", "_with_riskscore.csv", data_name)
+add_risk_score <- FALSE
+# covariates <- c("HighRiskInd", "Sex", "Age", "BMI", "MinorityInd")
+covariates <- c("MinorityInd", "HighRiskInd", "risk_score")
+
+ if("risk_score" %in% covariates) {
+  append_data <- "_with_riskscore"
+} else {
+  append_data <- ""
+}
+
+
 # Indicator variable for whether an event was observed (0 is censored or end of study, 1 is COVID endpoint)
 Event_Ind_variable <- list("Day57" = "EventIndPrimaryD57", "Day29" = "EventIndPrimaryD29") # "B" = "EventIndPrimaryD57")
 # Time until event (censoring, end of study, or COVID infection)
@@ -31,4 +58,7 @@ weight_variable <- list("Day57" = "wt.D57", "Day29" = "wt.D29")
 twophaseind_variable <- list("Day57" = "TwophasesampIndD57", "Day29" = "TwophasesampIndD29")
 # The stratum over which stratified two stage sampling is performed
 twophasegroup_variable <- "Wstratum"
-adjust_for_censoring <- FALSE # For now, set to FALSE. If set to TRUE, make sure you set tf well before we lose too many people to "end of study"
+ph1_id_list <-list("Day57" = "ph1.D57", "Day29" = "ph1.D29")
+ph2_id_list <-list("Day57" = "ph2.D57", "Day29" = "ph2.D29")
+
+fast_run <- grepl("Mock", study_name)

--- a/cop_mediation/code/run_analysis.R
+++ b/cop_mediation/code/run_analysis.R
@@ -35,18 +35,19 @@ if(fast_run){
 cat_result <- NULL
 quant_result <- NULL
 assay_col <- day_col <- NULL
-for (marker in markers) {
+for (marker in c(outer(times, assays, FUN=paste0))) {
   print(marker)
 
   time <- marker_to_time[[marker]]
 
   # quantitative marker
   data_full <- readRDS(here("data_clean", paste0("data_", time, ".rds")))
-  # check whether to perform the analysis with quantitative marker
-  perform_continuous_analysis <- 
-    min(data_full[data_full$Trt == 1 , marker], na.rm = TRUE) < 
-      max(data_full[data_full$Trt == 0, marker], na.rm = TRUE)
-
+  # # check whether to perform the analysis with quantitative marker
+  # perform_continuous_analysis <- 
+  #   min(data_full[data_full$Trt == 1 , marker], na.rm = TRUE) < 
+  #     max(data_full[data_full$Trt == 0, marker], na.rm = TRUE)
+  perform_continuous_analysis <- TRUE
+  
   if(perform_continuous_analysis){
 	  fit <- natmed2(
 	    W = data_full[, covariates, drop = FALSE],


### PR DESCRIPTION
@peterbriangilbert asked for the mediation analysis for Day 29 pseudoneut ID80 to be included in the CoR report for COVE. This PR implements this change by:
- modifying the `cop_mediation` code to only run the mediation analysis for this marker when analyzing a COVE-like data set
- including the `cop_mediation` report in the CoR report (we may eventually remove this after Moderna has compiled the report)

