### PR TITLE
turn off moderna cop report and janssen immuno report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,15 @@ jobs:
         - make data_processed
         - make risk_report
         - make cor_report
-    - name: Moderna CoP Report
-      env:
-        - REPORT_TYPE=COP
-        - TRIAL=moderna_mock
-      script:
-        - echo "Building correlates of protection report"
-        - make data_processed
-        - make risk_report
-        - make cop_report
+    # - name: Moderna CoP Report
+    #   env:
+    #     - REPORT_TYPE=COP
+    #     - TRIAL=moderna_mock
+    #   script:
+    #     - echo "Building correlates of protection report"
+    #     - make data_processed
+    #     - make risk_report
+    #     - make cop_report
     - name: Janssen Data Processing
       env:
         - REPORT_TYPE=IMMUNO
@@ -63,14 +63,14 @@ jobs:
       script:
         - echo "Processing data"
         - make data_processed
-    - name: Janssen Pooled Immuno Report
-      env:
-        - REPORT_TYPE=IMMUNO
-        - TRIAL=janssen_pooled_mock
-      script:
-        - echo "Building immunogenicity report"
-        - make data_processed
-        - make immuno_report
+    # - name: Janssen Pooled Immuno Report
+    #   env:
+    #     - REPORT_TYPE=IMMUNO
+    #     - TRIAL=janssen_pooled_mock
+    #   script:
+    #     - echo "Building immunogenicity report"
+    #     - make data_processed
+    #     - make immuno_report
     # - name: Janssen Pooled Correlates Report
     #   env:
     #     - REPORT_TYPE=COR


### PR DESCRIPTION
Because it is unclear when the cop report will be run for moderna, in order to expedite build times, I am removing the cop report build from `master` for the time being. I am also re-turning-off the ENSEMBLE immuno build that was errantly turned on in a recent PR.

@nhejazi FYI